### PR TITLE
[fix]: replace pcl_isnan with std::isnan

### DIFF
--- a/src/converter/pandar_to_velodyne.cpp
+++ b/src/converter/pandar_to_velodyne.cpp
@@ -78,10 +78,10 @@ bool has_nan(T point) {
     // remove nan point, or the feature assocaion will crash, the surf point will containing nan points
     // pcl remove nan not work normally
     // ROS_ERROR("Containing nan point!");
-    if (pcl_isnan(point.x) || pcl_isnan(point.y) || pcl_isnan(point.z)) {
-        return true;
+    if (std::isnan(point.x) || std::isnan(point.y) || std::isnan(point.z)) {
+      return true;
     } else {
-        return false;
+      return false;
     }
 }
 

--- a/src/converter/rs_to_velodyne.cpp
+++ b/src/converter/rs_to_velodyne.cpp
@@ -79,10 +79,10 @@ bool has_nan(T point) {
     // remove nan point, or the feature assocaion will crash, the surf point will containing nan points
     // pcl remove nan not work normally
     // ROS_ERROR("Containing nan point!");
-    if (pcl_isnan(point.x) || pcl_isnan(point.y) || pcl_isnan(point.z)) {
-        return true;
+    if (std::isnan(point.x) || std::isnan(point.y) || std::isnan(point.z)) {
+      return true;
     } else {
-        return false;
+      return false;
     }
 }
 


### PR DESCRIPTION
 According to pcl CHANGE LOG of pcl 1.10.0 on 2020.10.01:
* **[modernization]** Deprecate `pcl_isnan`, `pcl_isfinite`, and `pcl_isinf` in favor of `std` methods [[#2798](https://github.com/PointCloudLibrary/pcl/pull/2798), [#3457](https://github.com/PointCloudLibrary/pcl/pull/3457)]


