### PR TITLE
[Fix] Correct scale factor in rotation propagation (use scalar_type(0.5))

### DIFF
--- a/include/IKFoM_toolkit/esekfom/esekfom.hpp
+++ b/include/IKFoM_toolkit/esekfom/esekfom.hpp
@@ -309,7 +309,7 @@ public:
 				seg_SO3(i) = -1 * f_(dim + i) * dt;
 			}
 			MTK::SO3<scalar_type> res;
-			res.w() = MTK::exp<scalar_type, 3>(res.vec(), seg_SO3, scalar_type(1/2));
+			res.w() = MTK::exp<scalar_type, 3>(res.vec(), seg_SO3, scalar_type(0.5));
 		#ifdef USE_sparse
 			res_temp_SO3 = res.toRotationMatrix();
 			for(int i = 0; i < 3; i++){
@@ -341,7 +341,7 @@ public:
 			}
 			MTK::vect<2, scalar_type> vec = MTK::vect<2, scalar_type>::Zero();
 			MTK::SO3<scalar_type> res;
-			res.w() = MTK::exp<scalar_type, 3>(res.vec(), seg_S2, scalar_type(1/2));
+			res.w() = MTK::exp<scalar_type, 3>(res.vec(), seg_S2, scalar_type(0.5));
 			Eigen::Matrix<scalar_type, 2, 3> Nx;
 			Eigen::Matrix<scalar_type, 3, 2> Mx;
 			x_.S2_Nx_yy(Nx, idx);


### PR DESCRIPTION
### Summary
In the predict step of the filter, the rotation propagation is computed by applying an exponential map via MTK::exp. Previously, scalar_type(1/2) was used as the scale factor, but because of integer division, this evaluated to 0 instead of the intended 0.5. This resulted in an incorrect (negative or NaN) input being passed to MTK::cos_sinc_sqrt, causing an assertion failure.

### Changes
- Replaced scalar_type(1/2) with scalar_type(0.5) in the rotation propagation code within the predict step.
- This change ensures that the correct scale factor (0.5) is used when computing the exponential map for SO3 updates.

### Testing
- Verified that after this fix, the predict step runs without assertion failures and the rotation propagation behaves as expected.

### Notes
This fix addresses the propagation of the rotation state (in the predict step), ensuring numerical correctness by using the proper scale factor.